### PR TITLE
update pegjs-otf from 1.2.18 to 1.2.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bugs":                       "https://github.com/rse/astq/issues",
     "dependencies": {
         "pegjs":                  "0.10.0",
-        "pegjs-otf":              "1.2.18",
+        "pegjs-otf":              "1.2.19",
         "pegjs-util":             "1.4.21",
         "asty":                   "1.8.15",
         "cache-lru":              "1.1.11"


### PR DESCRIPTION
latest version of `pegjs-otf` uses [lodash that doesn't have sec vulnerability](https://github.com/rse/pegjs-otf/blob/1.2.19/package.json#L27)

trying to fix sec issue https://github.com/transferwise/neptune-web/security/dependabot/57